### PR TITLE
doc: add more docs about ThreadPool API

### DIFF
--- a/doc/all_doc.rst
+++ b/doc/all_doc.rst
@@ -1,0 +1,17 @@
+ThreadPool Doxygen
+==================
+
+Public interface
+----------------
+
+.. doxygenclass:: ThreadPool
+   :members:
+   :protected-members:
+   :no-link:
+
+Private
+-------
+
+.. doxygenclass:: ThreadPool
+   :private-members:
+   :no-link:

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -42,7 +42,7 @@ Note that we instantiate a task and wait for it to make sure the task is ran.
 With such a short program, it is possible that mypool will be deleted before a
 working is woke up to pick the task and run it. Waiting for the result ensure
 the task is ran. It is possible to use this syntax if you don't care about the
-return value or want to wait for a task to end
+return value or don't want to wait for a task to end:
 
 .. code-block:: c++
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,9 +11,8 @@ Welcome to threadpool's documentation!
    :caption: Contents:
 
    getting_started
-
-
-
+   pool_control
+   all_doc
 
 Indices and tables
 ==================

--- a/doc/pool_control.rst
+++ b/doc/pool_control.rst
@@ -1,0 +1,38 @@
+Pool Control
+============
+
+Pool size
+---------
+
+You can control the threadpool size when instantiating it with the constructors.
+Here are the different constructors you can use:
+
+.. doxygenfunction:: ThreadPool::ThreadPool(std::size_t)
+.. doxygenfunction:: ThreadPool::ThreadPool(std::size_t, std::size_t)
+
+The :code:`pool_size` parameter will determine the number of workers(threads)
+the pool will start when instantiating. The :code:`max_pool_size` is used by the
+pool to add more workers when all workers are working and a task comes in.
+
+For the first constructor, the :code:`max_pool_size` will be the
+:code:`pool_size` given as argument.
+
+Stopping the pool
+-----------------
+
+You can stop the pool with:
+
+.. doxygenfunction:: ThreadPool::stop()
+
+You can check if the pool is stopped with:
+
+.. doxygenfunction:: ThreadPool::is_stop()
+
+Checking the pool
+-----------------
+
+You can check the current state of the workers with:
+
+
+.. doxygenfunction:: ThreadPool::threads_available()
+.. doxygenfunction:: ThreadPool::threads_working()


### PR DESCRIPTION
Improve documentation and dump all ThreadPool doxygen in a single page in RTD.

Signed-off-by: Loic Reyreaud <loic.reyreaud@epita.fr>