### PR TITLE
bug: correct typenames used when forwarding to packaged task

### DIFF
--- a/doc/src/changelog.rst
+++ b/doc/src/changelog.rst
@@ -8,6 +8,8 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 
 Unreleased
 ----------
+- Corrected typenames when forwarding. Should avoid compilation issues in Visual
+  Studio 2017/2018
 
 [3.0.0] - 2018-11-26
 ----------

--- a/include/threadpool.hpp
+++ b/include/threadpool.hpp
@@ -328,7 +328,7 @@ auto ThreadPool::run(Function&& f, Args&&... args)
   // Create a packaged task from the callable object to fetch its result
   // with get_future()
   auto task = std::packaged_task<task_return_type()>(
-    std::bind(std::forward<Function&&>(f), std::forward<Args&&...>(args)...));
+    std::bind(std::forward<Function>(f), std::forward<Args...>(args)...));
   auto result = task.get_future();
 
   std::size_t idx = this->get_dispatch_worker();


### PR DESCRIPTION
Should fix #5. I think packaged_task does not expect && when receiving parameters. Visual Studio 2017/2018 seems to force the type passed as template parameter and result in an error, this should fix it.

Signed-off-by: Loic Reyreaud <loic.reyreaud@protonmail.com>